### PR TITLE
fix: Execute nested functions

### DIFF
--- a/src/function/function.js
+++ b/src/function/function.js
@@ -90,6 +90,9 @@ const findParameters = (data, predicateObjectMap, prefixes) => {
       if (param.template) {
         type = 'template';
       }
+      if (param.functionValue) {
+        type = 'functionValue'
+      }
       if (param[type] && param[type].length === 1) {
         param[type] = param[type][0];
       }

--- a/tests/nestedPredefinedFunctionMapping/input.json
+++ b/tests/nestedPredefinedFunctionMapping/input.json
@@ -1,0 +1,8 @@
+{
+  "name":"Tom A.",
+  "age":15,
+  "sports": {
+    "School": "Tennis",
+    "Private":"Football"
+  }
+}

--- a/tests/nestedPredefinedFunctionMapping/mapping.ttl
+++ b/tests/nestedPredefinedFunctionMapping/mapping.ttl
@@ -1,0 +1,69 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix prefix: <http://mytestprefix.org/> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix fnml: <http://semweb.mmlab.be/ns/fnml#> .
+@prefix fno: <http://w3id.org/function/ontology#> .
+@prefix sti: <http://sti2.at#> .
+@prefix grel: <http://users.ugent.be/~bjdmeest/function/grel.ttl#> .
+@base <http://sti2.at/> . #the base for the classes
+
+
+<#LOGICALSOURCE>
+rml:source "./tests/predefinedFunctionMapping/input.json";
+rml:referenceFormulation ql:JSONPath;
+rml:iterator "$".
+
+
+<#Mapping>
+rml:logicalSource <#LOGICALSOURCE>;
+
+ rr:subjectMap [
+    rr:termType rr:BlankNode;
+    rr:class prefix:Person;
+ ];
+
+
+rr:predicateObjectMap [
+    rr:predicate prefix:name;
+    rr:objectMap  <#FunctionMap>;
+];
+
+rr:predicateObjectMap [
+    rr:predicate prefix:age;
+    rr:objectMap [ rml:reference "age" ];
+].
+
+
+<#FunctionMap>
+    fnml:functionValue [
+        rr:predicateObjectMap [
+            rr:predicate fno:executes ;
+            rr:objectMap [ rr:constant sti:toUpperCase ]
+        ] ;
+        rr:predicateObjectMap [
+            rr:predicate grel:inputString ;
+            rr:objectMap <#SubFunctionMap>
+        ];
+    ] .
+
+<#SubFunctionMap>
+  fnml:functionValue [
+      rr:predicateObjectMap [
+          rr:predicate fno:executes ;
+          rr:objectMap [ rr:constant grel:string_substring ]
+      ] ;
+      rr:predicateObjectMap [
+          rr:predicate grel:valueParameter ;
+          rr:objectMap [ rml:reference "name" ]
+      ];
+      rr:predicateObjectMap [
+          rr:predicate grel:param_int_i_from ;
+          rr:objectMap [ rr:constant 0 ]
+      ];
+      rr:predicateObjectMap [
+          rr:predicate grel:param_int_i_opt_to ;
+          rr:objectMap [ rr:constant 3 ]
+      ];
+  ] .

--- a/tests/nestedPredefinedFunctionMapping/out.json
+++ b/tests/nestedPredefinedFunctionMapping/out.json
@@ -1,0 +1,8 @@
+[
+  {
+    "@type": "http://mytestprefix.org/Person",
+    "http://mytestprefix.org/name": "TOM",
+    "http://mytestprefix.org/age": "15",
+    "@id": "_:http%3A%2F%2Fsti2.at%2F%23Mapping_1"
+  }
+]

--- a/tests/test.js
+++ b/tests/test.js
@@ -335,6 +335,22 @@ it('Predefined option parameter function mapping', async () => {
   assert.equal(result[0].name, testString);
 });
 
+it('Nested predefined function mapping', async () => {
+  const options = {
+    functions: {
+      'http://users.ugent.be/~bjdmeest/function/grel.ttl#string_substring': function (data) {
+        const value = data['http://users.ugent.be/~bjdmeest/function/grel.ttl#valueParameter'];
+        const from = Number.parseInt(data['http://users.ugent.be/~bjdmeest/function/grel.ttl#param_int_i_from']['@value'], 10);
+        const to = Number.parseInt(data['http://users.ugent.be/~bjdmeest/function/grel.ttl#param_int_i_opt_to']['@value'], 10);
+        return value.slice(from, to);
+      },
+    },
+  };
+  let result = await parser.parseFile('./tests/nestedPredefinedFunctionMapping/mapping.ttl', './tests/nestedPredefinedFunctionMapping/out.json', options).catch((err) => { console.log(err); });
+  result = prefixhelper.deleteAllPrefixesFromObject(result, prefixes);
+  assert.equal(result[0].name, 'TOM');
+});
+
 it('Triple nested mapping', async () => {
   const options = {
     // replace: true,


### PR DESCRIPTION
Fixes #30 

With this change, there are now three places where the code repeats a nearly identical block to execute a function:
```
const definition = functionHelper.findDefinition(data, functionValue.predicateObjectMap, prefixes);
const parameters = functionHelper.findParameters(data, functionValue.predicateObjectMap, prefixes);
const calcParameters = await helper.calculateParams(Parser, parameters, index, options, data, prefixes);
const result = await functionHelper.executeFunction(definition, calcParameters, options);
```

When I have some time I can start refactoring that stuff, unless someone is already working in that direction. 
Some other work I'd love to see & help with in this repo is:
- Conversion to typescript
- More adherence to linting, I'm seeing tons of linter errors 