### PR TITLE
Add support when a CSVw object is used as `rml:source`

### DIFF
--- a/src/input-parser/logicalSourceParser.js
+++ b/src/input-parser/logicalSourceParser.js
@@ -9,7 +9,7 @@ const parseLogicalSource = (data, prefixes, id) => {
     throw `parseLogicalSource(): Error during processing logicalsource: could not find id: ${id}`;
   }
   const entryWithoutPrefixes = entry;
-  const source = entryWithoutPrefixes.source;
+  let source = entryWithoutPrefixes.source;
   let iterator = entryWithoutPrefixes.iterator;
   const ql = prefixhelper.checkAndRemovePrefixesFromString(
     entryWithoutPrefixes.referenceFormulation['@id'],
@@ -18,6 +18,10 @@ const parseLogicalSource = (data, prefixes, id) => {
   let referenceFormulation = entryWithoutPrefixes.referenceFormulation;
   if (ql === 'CSV') {
     iterator = '$';
+  }
+  if (typeof source === 'object' && source['url']) {
+    // In case a csvw object is used as source (e.g. ldwizard generated RML)
+    source = source['url']
   }
   if (source && iterator && referenceFormulation) {
     switch (typeof referenceFormulation) {


### PR DESCRIPTION
Hi @sumutcan and @ThibaultGerrier, this pull request adds code that check if the `rml:source` found in the parsed RDF is an object with a `url` property , and extract the `url` property value to be used as the source path if present. 

Which allows to use CSVw object as `rml:source` in RML mappings, e.g.:

```turtle
@prefix rml: <http://semweb.mmlab.be/ns/rml#>.
@prefix csvw: <http://www.w3.org/ns/csvw#>.

:TriplesMap rdf:type rr:TriplesMap;
    rml:logicalSource [
        rml:source [
            rdf:type csvw:Table;
            csvw:url "input_data.csv";
            csvw:dialect [
                rdf:type csvw:Dialect;
                csvw:delimiter ",";
                csvw:encoding "UTF-8"
            ]
        ];
        rml:referenceFormulation ql:CSV
    ];
```

This solves the issue mentionned in https://github.com/semantifyit/RocketRML/issues/40 without impacting the previous behavior of the RocketRML: using a string as `rml:source` still work as before, as I far as I tested (`npm run test` pass)

Merging this pull request will allow to use RocketRML in the LDWizard (cf. https://github.com/pldn/LDWizard/issues/54)

The RML team is currently discussing on clarifying the specifications around `rml:source`, which currently are expected to be an URI according to the RML specs. 
This would be a first step in the direction of supporting objects as `rml:source` in RocketRML, which seems to be the direction RML is taking (note that the `rmlmapper-java` already supports using a CSVw Table object with `csvw:url` for `rml:source`)

Let me know if there are any changes you'll like to see in the pull requests